### PR TITLE
ci(claude): Improve Claude Code Actions PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,15 +49,30 @@ jobs:
             - Security implications
             - Test coverage
             
+            Please follow these steps to proceed with PR creation:
+            1.  **Start the review:** 
+              - Use `mcp__github__create_pending_pull_request_review` to initiate a pending review
+            2.  **Check the changes:** 
+              - Use `mcp__github__get_pull_request_diff` to understand code changes and line numbers
+            3.  **Add inline comments:** 
+              - Use `mcp__github__add_pull_request_review_comment_to_pending_review` to add comments for code lines with improvements or concerns
+              - When the fix approach is clear, actively use suggestions
+            4.  **Submit the review:** 
+              - Use `mcp__github__submit_pending_pull_request_review` with event type set to "COMMENT" and submit the review with an overall summary comment
+              - ※Please do not use "REQUEST_CHANGES"
+            
             Please provide inline comments on specific lines of code with categorized feedback:
             - [MUST] Critical issues requiring immediate attention
             - [IMO] Optional suggestions for consideration
             - [nits] Minor style or formatting improvements
-            
-            Include an overall summary of your review.
                         
           # Remove tool restrictions - let Claude use default tools for PR reviews
-          
+          allowed_tools: >
+            mcp__github__create_pending_pull_request_review,
+            mcp__github__add_pull_request_review_comment_to_pending_review,
+            mcp__github__submit_pending_pull_request_review,
+            mcp__github__get_pull_request_diff
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,11 +61,14 @@ jobs:
               - Use `mcp__github__submit_pending_pull_request_review` with event type set to "COMMENT" and submit the review with an overall summary comment
               - ※Please do not use "REQUEST_CHANGES"
             
-            Please provide inline comments on specific lines of code with categorized feedback:
-            - [MUST] Critical issues requiring immediate attention
-            - [IMO] Optional suggestions for consideration
-            - [nits] Minor style or formatting improvements
-                        
+            **Inline comment guidelines:**
+            - Please provide inline comments on specific lines of code with categorized feedback:
+              - [MUST] Critical issues requiring immediate attention: bugs, security issues, and mandatory fixes
+              - [IMO] Optional suggestions for consideration: performance, readability, and style improvements
+              - [nits] Minor style or formatting improvements: code style and minor improvements
+            - Please focus on code lines with improvements or concerns
+            - Please include positive feedback and overall evaluation in the summary comment
+
           # Remove tool restrictions - let Claude use default tools for PR reviews
           allowed_tools: >
             mcp__github__create_pending_pull_request_review,


### PR DESCRIPTION
## Summary

- Add structured Japanese instructions for PR review process
- Configure allowed MCP GitHub tools for more focused reviews
- Improve clarity of review workflow with step-by-step guidance

## Changes

- **Enhanced PR review instructions**: Added Japanese language instructions explaining the 4-step review process
- **Tool restrictions**: Configured `allowed_tools` to specify which MCP GitHub tools can be used during reviews
- **Improved workflow structure**: Added clear step-by-step guidance for conducting PR reviews

## Test plan

- [ ] Verify the workflow runs successfully on new PRs
- [ ] Confirm Claude follows the Japanese instructions when reviewing
- [ ] Check that only specified MCP tools are available during reviews
- [ ] Test the structured review process produces better quality feedback